### PR TITLE
Create/Update/Delete secrets to store vpn configs internally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+bin
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Kubernetes Generated files - skip generated files, except for vendored files
+
+!vendor/**/zz_generated.*
+
+# editor and IDE paraphernalia
+.idea
+*.swp
+*.swo
+*~

--- a/pkg/controller/vpn/vpn_controller.go
+++ b/pkg/controller/vpn/vpn_controller.go
@@ -273,6 +273,7 @@ func (r *ReconcileVPN) createSecret(secretname string, vpn *networkingv1alpha1.V
 	}
 
 	if err := controllerutil.SetControllerReference(vpn, secret, r.scheme); err != nil {
+		log.Error(err, "error setting owner reference to secret", "secretName", secretname)
 		return err
 	}
 


### PR DESCRIPTION
*Description of changes:*
- controller will use the secret name passed in spec to create k8s secret
- this change removes the requirement of empty/dummy secrets need to be there before reconcile runs
- controller will update and delete the secrets with change in VPN resource

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
