### PR TITLE
Get all routetable IDs for a vpc and stop relying on tag values

### DIFF
--- a/pkg/aws/ec2helper_test.go
+++ b/pkg/aws/ec2helper_test.go
@@ -21,7 +21,7 @@ func TestGetRouteTableIDs(t *testing.T) {
 			name:     "Returns both a public and private route table id",
 			EC2API:   &MockEC2API{},
 			VpcID:    "test-vpc-id",
-			expected: []string{"PublicRouteTableId", "PrivateRouteTableId"},
+			expected: []string{"RouteTableId1", "RouteTableId2", "RouteTableId3"},
 		},
 	}
 	for _, tc := range tests {

--- a/pkg/aws/ec2helper_test.go
+++ b/pkg/aws/ec2helper_test.go
@@ -15,22 +15,19 @@ func TestGetRouteTableIDs(t *testing.T) {
 		name     string
 		EC2API   *MockEC2API
 		VpcID    string
-		expected RouteTableIDs
+		expected []string
 	}{
 		{
-			name:   "Returns both a public and private route table id",
-			EC2API: &MockEC2API{},
-			VpcID:  "test-vpc-id",
-			expected: RouteTableIDs{
-				Public:  "PublicRouteTableId",
-				Private: "PrivateRouteTableId",
-			},
+			name:     "Returns both a public and private route table id",
+			EC2API:   &MockEC2API{},
+			VpcID:    "test-vpc-id",
+			expected: []string{"PublicRouteTableId", "PrivateRouteTableId"},
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			result, _ := GetRouteTableIDs(tc.EC2API, tc.VpcID)
-			if result != tc.expected {
+			if !reflect.DeepEqual(result, tc.expected) {
 				t.Errorf(`Expected result %v, Got %v`, tc.expected, result)
 			}
 		})

--- a/pkg/aws/fake.go
+++ b/pkg/aws/fake.go
@@ -71,14 +71,10 @@ func (m *MockEC2API) DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.De
 			},
 				OwnerId:         aws.String("test-OwnerId"),
 				PropagatingVgws: []*ec2.PropagatingVgw{&ec2.PropagatingVgw{}},
-				RouteTableId:    aws.String("PublicRouteTableId"),
+				RouteTableId:    aws.String("RouteTableId1"),
 				Routes: []*ec2.Route{
 					&ec2.Route{},
 				},
-				Tags: []*ec2.Tag{&ec2.Tag{
-					Key:   aws.String("foo"),
-					Value: aws.String("PublicRouteTable"),
-				}},
 				VpcId: aws.String("test-vpc-id"),
 			},
 			&ec2.RouteTable{Associations: []*ec2.RouteTableAssociation{
@@ -91,14 +87,26 @@ func (m *MockEC2API) DescribeRouteTables(*ec2.DescribeRouteTablesInput) (*ec2.De
 			},
 				OwnerId:         aws.String("test-OwnerId"),
 				PropagatingVgws: []*ec2.PropagatingVgw{&ec2.PropagatingVgw{}},
-				RouteTableId:    aws.String("PrivateRouteTableId"),
+				RouteTableId:    aws.String("RouteTableId2"),
 				Routes: []*ec2.Route{
 					&ec2.Route{},
 				},
-				Tags: []*ec2.Tag{&ec2.Tag{
-					Key:   aws.String("foo"),
-					Value: aws.String("PrivateRouteTable"),
-				}},
+				VpcId: aws.String("test-vpc-id"),
+			},
+			&ec2.RouteTable{Associations: []*ec2.RouteTableAssociation{
+				&ec2.RouteTableAssociation{
+					Main:                    aws.Bool(true),
+					RouteTableAssociationId: aws.String("test-RouteTableAssociationId"),
+					RouteTableId:            aws.String("test-RouteTableId"),
+					SubnetId:                aws.String("test-SubnetId"),
+				},
+			},
+				OwnerId:         aws.String("test-OwnerId"),
+				PropagatingVgws: []*ec2.PropagatingVgw{&ec2.PropagatingVgw{}},
+				RouteTableId:    aws.String("RouteTableId3"),
+				Routes: []*ec2.Route{
+					&ec2.Route{},
+				},
 				VpcId: aws.String("test-vpc-id"),
 			},
 		},

--- a/pkg/controller/vpn/cfn_template.go
+++ b/pkg/controller/vpn/cfn_template.go
@@ -21,8 +21,9 @@ Resources:
     Type: AWS::EC2::VPNGatewayRoutePropagation
     Properties:
       RouteTableIds:
-        - {{ .PublicRouteTableID }}
-        - {{ .PrivateRouteTableID }}
+{{- range $i, $e := .RouteTableIDs }}
+        - {{ $e }}
+{{- end }}
       VpnGatewayId: !Ref 'VPNGateway'
     DependsOn: VPCGatewayAttachment
 

--- a/pkg/controller/vpn/vpn_controller.go
+++ b/pkg/controller/vpn/vpn_controller.go
@@ -108,10 +108,9 @@ type ReconcileVPN struct {
 }
 
 type cfnTemplateInput struct {
-	VpcID               string
-	VPNConnections      []networkingv1alpha1.VPNConnection
-	PublicRouteTableID  string
-	PrivateRouteTableID string
+	VpcID          string
+	VPNConnections []networkingv1alpha1.VPNConnection
+	RouteTableIDs  []string
 }
 
 // Status Codes for the VPN Object
@@ -325,10 +324,9 @@ func (r *ReconcileVPN) createVPNStack(instance *networkingv1alpha1.VPN) error {
 	}
 
 	cfnTemplate, err := awsHelper.GetCFNTemplateBody(vpnCFNTemplate, cfnTemplateInput{
-		VpcID:               vpcID,
-		VPNConnections:      instance.Spec.VPNConnections,
-		PrivateRouteTableID: rtbs.Private,
-		PublicRouteTableID:  rtbs.Public,
+		VpcID:          vpcID,
+		VPNConnections: instance.Spec.VPNConnections,
+		RouteTableIDs:  rtbs,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
*Description of changes:*
- If EKS cluster is not created by `eksctl`, then reconcile gives `"error":"route table ids not found"`
- This change adds all the route table ids for a vpc into VPNGatewayRoutePropagation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
